### PR TITLE
Handled multiple query filter in cf routes

### DIFF
--- a/app/controllers/runtime/routes_controller.rb
+++ b/app/controllers/runtime/routes_controller.rb
@@ -31,15 +31,14 @@ module VCAP::CloudController
     def delete(guid)
       do_delete(find_guid_and_validate_access(:delete, guid))
     end
-    
+
     def get_filtered_dataset_for_enumeration(model, ds, qp, opts)
-      single_filter = opts[:q][0] if opts[:q]
+      orgIndex = opts[:q].index {|query| query.start_with?('organization_guid:') } if opts[:q]
+      if orgIndex != nil
+        org_guid = opts[:q][orgIndex].split(':')[1]
+        opts[:q].delete(opts[:q][orgIndex])
 
-      if single_filter && single_filter.start_with?('organization_guid')
-        org_guid = single_filter.split(':')[1]
-
-        Query.
-          filtered_dataset_from_query_params(model, ds, qp, { q: '' }).
+        super(model, ds, qp, opts).
           select_all(:routes).
           left_join(:spaces, id: :routes__space_id).
           left_join(:organizations, id: :spaces__organization_id).

--- a/spec/unit/controllers/runtime/routes_controller_spec.rb
+++ b/spec/unit/controllers/runtime/routes_controller_spec.rb
@@ -226,7 +226,33 @@ module VCAP::CloudController
 		  expect(decoded_response['resources'].length).to eq(1)
 		  expect(first_route_info.fetch('metadata').fetch('guid')).to eq(route_guid)
 		end
+
+		it 'Allows organization_guid query at any place in query ' do
+                  org_guid = organization.guid
+                  route_guid = route.guid
+		  domain_guid = domain.guid
+
+                  get "v2/routes?q=domain_guid:#{domain_guid}&q=organization_guid:#{org_guid}", {}, admin_headers
+
+                  expect(last_response.status).to eq(200)
+                  expect(decoded_response['resources'].length).to eq(1)
+                  expect(first_route_info.fetch('metadata').fetch('guid')).to eq(route_guid)
+                end
 		
+		it 'Allows organization_guid query at any place in query with all querables' do
+                  org_guid = organization.guid
+                  taken_host = "someroute"
+                  routeTemp = Route.make(host: taken_host, domain: domain, space: space)
+		  route_guid = routeTemp.guid
+                  domain_guid = domain.guid
+
+                  get "v2/routes?q=host:#{taken_host}&q=organization_guid:#{org_guid}&q=domain_guid:#{domain_guid}", {}, admin_headers
+
+                  expect(last_response.status).to eq(200)
+                  expect(decoded_response['resources'].length).to eq(1)
+                  expect(first_route_info.fetch('metadata').fetch('guid')).to eq(route_guid)
+                end
+
 		it 'Allows filtering at organization level' do		  
 		  org_guid = organization.guid		  
 		  route_guid = route.guid


### PR DESCRIPTION
Now organization_guid filter can be clubbed along with other
query filters (host,domain_guid)
