### PR TITLE
Allowing prior state as a part of metadata for all app.update events

### DIFF
--- a/app/controllers/runtime/apps_controller.rb
+++ b/app/controllers/runtime/apps_controller.rb
@@ -112,6 +112,15 @@ module VCAP::CloudController
       record_app_create_value if request_attrs
     end
 
+    def before_update(app)
+      save_state_before_update(app)
+    end
+
+    def save_state_before_update(app)
+      state = app.state
+      app.define_singleton_method(:state_before_update) { state }
+    end
+
     def after_update(app)
       stager_response = app.last_stager_response
       if stager_response.respond_to?(:streaming_log_url) && stager_response.streaming_log_url

--- a/app/repositories/runtime/app_event_repository.rb
+++ b/app/repositories/runtime/app_event_repository.rb
@@ -18,7 +18,11 @@ module VCAP::CloudController
           Loggregator.emit(app.guid, "Updated app with guid #{app.guid} (#{app_audit_hash(request_attrs)})")
 
           actor = { name: actor_name, guid: actor.guid, type: 'user' }
-          metadata = { request: app_audit_hash(request_attrs) }
+          if app.respond_to?(:state_before_update)
+            metadata = { request: app_audit_hash(request_attrs), previous_state: { state: app.state_before_update } }
+          else
+            metadata = { request: app_audit_hash(request_attrs) }
+          end
           create_app_audit_event('audit.app.update', app, space, actor, metadata)
         end
 


### PR DESCRIPTION
Solution to the story :- 'As a CF api consumer I expect that /v2/events returns prior state as a part of its metadata for all app.update events'
[#74624460]

/v2/events will contain prior state as part of metadata for all app.update event.
For Example : 
```
{
         "metadata": {
            "guid": "efcf3dab-4314-406c-b796-98973cff1abf",
            "url": "/v2/events/efcf3dab-4314-406c-b796-98973cff1abf",
            "created_at": "2015-01-28T12:13:17+00:00",
            "updated_at": null
         },
         "entity": {
            "type": "audit.app.update",
            "actor": "c85f70bb-0e7f-44f1-ae2b-63429309c89c",
            "actor_type": "user",
            "actor_name": "admin",
            "actee": "fbeb946e-c2fd-49c3-abf7-99918c1572a2",
            "actee_type": "app",
            "actee_name": "Dev6",
            "timestamp": "2015-01-28T12:13:17+00:00",
            "metadata": {
               "request": {
                  "state": "STARTED"
               },
               "previous_state": {
                  "state": "STOPPED"
               }
            },
            "space_guid": "57921333-7f00-4151-8dc3-fc654e8e332f",
            "organization_guid": "e28b54ce-acff-4dac-afe7-ad59fd446f53"
         }
      }
```

Issue : http://rnd-github.huawei.com/cloudfoundry/cloud_controller_ng/issues/3