### PR TITLE
Added prior state to app.update event

### DIFF
--- a/app/controllers/runtime/apps_controller.rb
+++ b/app/controllers/runtime/apps_controller.rb
@@ -112,6 +112,15 @@ module VCAP::CloudController
       record_app_create_value if request_attrs
     end
 
+    def before_update(app)
+      save_state_before_update(app)
+    end
+
+    def save_state_before_update(app)
+      state = app.state
+      app.define_singleton_method(:state_before_update) { state }
+    end
+
     def after_update(app)
       stager_response = app.last_stager_response
       if stager_response.respond_to?(:streaming_log_url) && stager_response.streaming_log_url

--- a/app/models/runtime/app.rb
+++ b/app/models/runtime/app.rb
@@ -549,6 +549,19 @@ module VCAP::CloudController
       app_event_repository.record_unmap_route(self, route, SecurityContext.current_user, SecurityContext.current_user_email)
     end
 
+    def prior_state
+      changes = previous_changes
+      return self.state unless changes
+
+      if changes.key?(:state)
+        return changes[:state][0]
+      elsif changes.key?(:staging_task_id)
+        return 'STOPPED'
+      end
+
+      self.state
+    end
+
     private
 
     def mark_routes_changed(_=nil)

--- a/app/models/v3/domain/app_process.rb
+++ b/app/models/v3/domain/app_process.rb
@@ -2,7 +2,7 @@ module VCAP::CloudController
   class AppProcess
     attr_reader :guid, :space_guid, :stack_guid, :disk_quota,
       :memory, :instances, :state, :command, :buildpack, :health_check_timeout,
-      :docker_image, :environment_json, :name, :type
+      :docker_image, :environment_json, :name, :type, :prior_state
 
     def initialize(opts)
       opts.symbolize_keys!
@@ -20,6 +20,7 @@ module VCAP::CloudController
       @state                = opts[:state]
       @type                 = opts[:type] || 'web'
       @name                 = opts[:name] || "v3-proc-#{@type}-#{@guid}"
+      @prior_state          = opts[:prior_state]
     end
 
     def with_changes(changes)
@@ -38,6 +39,7 @@ module VCAP::CloudController
         state:                  self.state,
         type:                   self.type,
         name:                   self.name,
+        prior_state:            self.prior_state,
       }.merge(changes.symbolize_keys))
     end
   end

--- a/app/models/v3/mappers/process_mapper.rb
+++ b/app/models/v3/mappers/process_mapper.rb
@@ -15,7 +15,8 @@ module VCAP::CloudController
         'health_check_timeout' => model.values[:health_check_timeout],
         'docker_image'         => model.values[:docker_image],
         'environment_json'     => model.environment_json,
-        'type'                 => model.type
+        'type'                 => model.type,
+        'prior_state'          => model.prior_state
       })
     end
 

--- a/app/repositories/runtime/app_event_repository.rb
+++ b/app/repositories/runtime/app_event_repository.rb
@@ -18,7 +18,11 @@ module VCAP::CloudController
           Loggregator.emit(app.guid, "Updated app with guid #{app.guid} (#{app_audit_hash(request_attrs)})")
 
           actor = { name: actor_name, guid: actor.guid, type: 'user' }
-          metadata = { request: app_audit_hash(request_attrs) }
+          if app.respond_to?(:state_before_update)
+            metadata = { request: app_audit_hash(request_attrs), previous_state: { state: app.state_before_update } }
+          else
+            metadata = { request: app_audit_hash(request_attrs) }
+          end
           create_app_audit_event('audit.app.update', app, space, actor, metadata)
         end
 

--- a/app/repositories/runtime/app_event_repository.rb
+++ b/app/repositories/runtime/app_event_repository.rb
@@ -18,11 +18,7 @@ module VCAP::CloudController
           Loggregator.emit(app.guid, "Updated app with guid #{app.guid} (#{app_audit_hash(request_attrs)})")
 
           actor = { name: actor_name, guid: actor.guid, type: 'user' }
-          if app.respond_to?(:state_before_update)
-            metadata = { request: app_audit_hash(request_attrs), previous_state: { state: app.state_before_update } }
-          else
-            metadata = { request: app_audit_hash(request_attrs) }
-          end
+          metadata = { request: app_audit_hash(request_attrs), prior_state: app.prior_state }
           create_app_audit_event('audit.app.update', app, space, actor, metadata)
         end
 

--- a/spec/api/api_version_spec.rb
+++ b/spec/api/api_version_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'digest/sha1'
 
 describe 'Stable API warning system', api_version_check: true do
-  API_FOLDER_CHECKSUM = '7285b5a648d967aa4ec8943dc224b56a41c89a32'
+  API_FOLDER_CHECKSUM = 'fac70466aa0a7622dee3cd1396ecf606d7147e1a'
 
   it 'double-checks the version' do
     expect(VCAP::CloudController::Constants::API_VERSION).to eq('2.21.0')

--- a/spec/api/documentation/events_api_spec.rb
+++ b/spec/api/documentation/events_api_spec.rb
@@ -166,6 +166,7 @@ resource 'Events', type: [:api, :legacy_api] do
                                space_guid: test_app.space.guid,
                                metadata: {
                                  'request' => expected_app_request,
+                                 'prior_state' => test_app.prior_state,
                                }
     end
 

--- a/spec/unit/controllers/runtime/apps_controller_spec.rb
+++ b/spec/unit/controllers/runtime/apps_controller_spec.rb
@@ -139,8 +139,8 @@ module VCAP::CloudController
 
       let(:app_obj) { AppFactory.make(instances: 1) }
 
-      def update_app(app=app_obj)
-        put "/v2/apps/#{app.guid}", MultiJson.dump(update_hash), json_headers(admin_headers)
+      def update_app
+        put "/v2/apps/#{app_obj.guid}", MultiJson.dump(update_hash), json_headers(admin_headers)
       end
 
       describe 'app_scaling feature flag' do
@@ -185,7 +185,7 @@ module VCAP::CloudController
             update_app
           end
 
-          it 'receive previous state' do
+          it 'receive prior state' do
             allow(app_event_repository).to receive(:record_app_update).and_call_original
 
             update_app
@@ -196,7 +196,7 @@ module VCAP::CloudController
               expect(user).to eq(admin_user)
               expect(user_name).to eq(SecurityContext.current_user_email)
               expect(attributes).to eq({ 'instances' => 2 })
-              expect(recorded_app.state_before_update).to eq('STOPPED')
+              expect(recorded_app.prior_state).to eq('STOPPED')
             end
           end
         end
@@ -216,38 +216,7 @@ module VCAP::CloudController
               expect(user).to eq(admin_user)
               expect(user_name).to eq(SecurityContext.current_user_email)
               expect(attributes).to eq({ 'state' => 'STARTED' })
-              expect(recorded_app.state_before_update).to eq('STOPPED')
-            end
-          end
-
-          it 'records the previous state fields on the event' do
-            allow(app_event_repository).to receive(:record_app_update).and_call_original
-
-            update_app
-
-            arg = nil
-            expect(app_event_repository).to have_received(:record_app_update) do |*args|
-              arg = args
-            end
-
-            event = app_event_repository.record_app_update(*arg).reload
-            expect(event.metadata.fetch('previous_state')).to eq({ 'state' => 'STOPPED' })
-          end
-
-          it 'records the previous state separately for different apps' do
-            update_app(app_tmp_obj)
-
-            allow(app_event_repository).to receive(:record_app_update).and_call_original
-
-            update_app(app_obj)
-
-            expect(app_event_repository).to have_received(:record_app_update) do |recorded_app, recorded_space, user, user_name, attributes|
-              expect(recorded_app.guid).to eq(app_obj.guid)
-              expect(recorded_app.state).to eq('STARTED')
-              expect(user).to eq(admin_user)
-              expect(user_name).to eq(SecurityContext.current_user_email)
-              expect(attributes).to eq({ 'state' => 'STARTED' })
-              expect(recorded_app.state_before_update).to eq('STOPPED')
+              expect(recorded_app.prior_state).to eq('STOPPED')
             end
           end
         end


### PR DESCRIPTION
Story: [#74624460]
As per review comment , This fix is without meta-programming .
Added a method prior_state in app class which will decide and return prior
state of app by analysing current state of app and changes returned by dirty plugin.

Additionally , same repository is getting used in ProcessesHandler class which passed AppProcess object after app update .
So , added one instance variable prior state in  AppProcess class to get updated prior state of app.