### PR TITLE
Added order-by query parameter

### DIFF
--- a/lib/cloud_controller/rest_controller/common_params.rb
+++ b/lib/cloud_controller/rest_controller/common_params.rb
@@ -20,6 +20,7 @@ module VCAP::CloudController::RestController
         ['orphan-relations',       Integer],
         ['exclude-relations',      String],
         ['include-relations',      String],
+        ['order-by',               String],
 
       ].each do |key, klass|
         val = params[key]
@@ -37,6 +38,10 @@ module VCAP::CloudController::RestController
 
       if res[:include_relations]
         res[:include_relations] = res[:include_relations].split(',')
+      end
+
+      if res[:order_by]
+        res[:order_by] = res[:order_by].split(',')
       end
 
       res

--- a/lib/cloud_controller/rest_controller/paginated_collection_renderer.rb
+++ b/lib/cloud_controller/rest_controller/paginated_collection_renderer.rb
@@ -126,6 +126,7 @@ module VCAP::CloudController::RestController
       params['orphan-relations'] = opts[:orphan_relations] if opts[:orphan_relations]
       params['exclude-relations'] = opts[:exclude_relations] if opts[:exclude_relations]
       params['include-relations'] = opts[:include_relations] if opts[:include_relations]
+      params['order-by'] = opts[:order_by].join(',') if opts[:order_by]
 
       controller.preserve_query_parameters.each do |preseved_param|
         params[preseved_param] = request_params[preseved_param] if request_params[preseved_param]

--- a/spec/support/api_dsl.rb
+++ b/spec/support/api_dsl.rb
@@ -199,6 +199,7 @@ module ApiDsl
         request_parameter :q, query_parameter_description, { html: true, example_values: examples }
       end
       pagination_parameters
+      request_parameter :'order-by', 'comma-delimited list of the column for sorting to include in response', deprecated: false
       request_parameter :'inline-relations-depth', "0 - don't inline any relations and return URLs.  Otherwise, inline to depth N.", deprecated: true
       request_parameter :'orphan-relations', '0 - de-duplicate object entries in response', deprecated: true
       request_parameter :'exclude-relations', 'comma-delimited list of relations to drop from response', deprecated: true

--- a/spec/unit/lib/rest_controller/common_params_spec.rb
+++ b/spec/unit/lib/rest_controller/common_params_spec.rb
@@ -27,6 +27,10 @@ module VCAP::CloudController::RestController
         expect(common_params.parse({ 'include-relations' => 'name1,name2' })).to eq({ include_relations: ['name1', 'name2'] })
       end
 
+      it 'treats order-by as a String Array and symbolizes the key' do
+        expect(common_params.parse({ 'order-by' => 'name1,name2' })).to eq({ order_by: ['name1', 'name2'] })
+      end
+
       it 'treats page as an Integer and symbolizes the key' do
         expect(common_params.parse({ 'page' => '123' })).to eq({ page: 123 })
       end

--- a/spec/unit/lib/rest_controller/paginated_collection_renderer_spec.rb
+++ b/spec/unit/lib/rest_controller/paginated_collection_renderer_spec.rb
@@ -293,6 +293,44 @@ module VCAP::CloudController::RestController
         end
       end
 
+      context 'when order-by' do
+        before do
+          VCAP::CloudController::TestModel.make
+          VCAP::CloudController::TestModel.make
+          VCAP::CloudController::TestModel.make
+        end
+
+        let(:opts) do
+          {
+            results_per_page: 1,
+            order_by: order_by,
+            page: 2
+          }
+        end
+
+        context 'is specified' do
+          let(:order_by) { ['id', 'created_at'] }
+
+          it 'includes order-by in next_url and prev_url' do
+            prev_url = JSON.parse(render_json_call)['prev_url']
+            next_url = JSON.parse(render_json_call)['next_url']
+            expect(prev_url).to include('order-by=id,created_at')
+            expect(next_url).to include('order-by=id,created_at')
+          end
+        end
+
+        context 'is not specified' do
+          let(:order_by) { nil }
+
+          it 'does not include order-by in next_url and prev_url' do
+            prev_url = JSON.parse(render_json_call)['prev_url']
+            next_url = JSON.parse(render_json_call)['next_url']
+            expect(prev_url).to_not include('order-by')
+            expect(next_url).to_not include('order-by')
+          end
+        end
+      end
+
       context 'when collection_transformer is given' do
         let(:collection_transformer) { double('collection_transformer') }
         let!(:test_model) { VCAP::CloudController::TestModel.make }


### PR DESCRIPTION
User can get sorted response based on order set provided.
Order set is comma-delimited.
This patch is submitted to implement CLI story
https://www.pivotaltracker.com/n/projects/892938/stories/91314240
https://www.pivotaltracker.com/n/projects/892938/stories/62876392
to get org/space list alphabetically sorted.