### PR TITLE
current usage against the org quota

### DIFF
--- a/app/collection_transformers/quota_usage_populator.rb
+++ b/app/collection_transformers/quota_usage_populator.rb
@@ -1,0 +1,48 @@
+module VCAP::CloudController
+  class QuotaUsagePopulator
+    def transform(quota, opts={})
+      org_id = opts[:organization_id]
+
+      unless org_id.nil?
+        spaces = Space.where(organization: quota.organizations_dataset.filter(id: org_id))
+        quota.org_usage = map_organization_usage(spaces) unless spaces.nil?
+      end
+    end
+
+    private
+
+    def map_organization_usage(spaces)
+      quota = {}
+      quota['routes'] = organization_routes_count(spaces)
+      quota['services'] = organization_services_count(spaces)
+      quota['memory'] = organization_memory_usage(spaces)
+      quota
+    end
+
+    def organization_routes_count(spaces)
+      route_count = 0
+      spaces.eager(:routes).all do |space|
+        route_count += space.routes.count
+      end
+      route_count
+    end
+
+    def organization_services_count(spaces)
+      service_count = 0
+      spaces.eager(:service_instances).all do |space|
+        service_count += space.service_instances.count
+      end
+      service_count
+    end
+
+    def organization_memory_usage(spaces)
+      memory_usage = 0
+      spaces.eager(:apps).all do |space|
+        space.apps.each do |app|
+          memory_usage += app.memory * app.instances if app.started?
+        end
+      end
+      memory_usage
+    end
+  end
+end

--- a/app/controllers/runtime/organizations_controller.rb
+++ b/app/controllers/runtime/organizations_controller.rb
@@ -4,12 +4,13 @@ require 'queries/organization_user_roles_fetcher'
 module VCAP::CloudController
   class OrganizationsController < RestController::ModelController
     def self.dependencies
-      [:username_and_roles_populating_collection_renderer]
+      [:username_and_roles_populating_collection_renderer, :quota_usage_populating_collection_renderer]
     end
 
     def inject_dependencies(dependencies)
       super
       @user_roles_collection_renderer = dependencies.fetch(:username_and_roles_populating_collection_renderer)
+      @quota_usage_collection_renderer = dependencies.fetch(:quota_usage_populating_collection_renderer)
     end
 
     define_attributes do
@@ -63,6 +64,24 @@ module VCAP::CloudController
         associated_path,
         opts,
         {},
+      )
+    end
+
+    get '/v2/organizations/:guid/quota_usage', :enumerate_quota_usage
+    def enumerate_quota_usage(guid)
+      logger.debug('cc.enumerate.related', guid: guid, association: 'quota_usage')
+
+      org = find_guid_and_validate_access(:read, guid)
+
+      associated_controller, associated_model = QuotaDefinitionsController, QuotaDefinition
+      ds = find_guid_and_validate_access(:read, org.quota_definition.guid, associated_model)
+
+      opts = @opts.merge(transform_opts: { organization_id: org.id })
+
+      @quota_usage_collection_renderer.render_json(
+        associated_controller,
+        ds,
+        opts,
       )
     end
 

--- a/app/models/runtime/quota_definition.rb
+++ b/app/models/runtime/quota_definition.rb
@@ -2,6 +2,8 @@ module VCAP::CloudController
   class QuotaDefinition < Sequel::Model
     one_to_many :organizations
 
+    attr_accessor :org_usage
+
     export_attributes :name, :non_basic_services_allowed, :total_services, :total_routes,
                       :memory_limit, :trial_db_allowed, :instance_memory_limit
     import_attributes :name, :non_basic_services_allowed, :total_services, :total_routes,
@@ -34,6 +36,12 @@ module VCAP::CloudController
 
     def self.configure(config)
       @default_quota_name = config[:default_quota_definition]
+    end
+
+    def to_hash(opts={})
+      return super(opts) unless org_usage
+
+      super(opts).merge!('org_usage' => org_usage)
     end
 
     class << self

--- a/lib/cloud_controller/rest_controller/object_renderer.rb
+++ b/lib/cloud_controller/rest_controller/object_renderer.rb
@@ -2,12 +2,15 @@ require 'addressable/uri'
 
 module VCAP::CloudController::RestController
   class ObjectRenderer
+    attr_reader :collection_transformer
+
     def initialize(eager_loader, serializer, opts)
       @eager_loader = eager_loader
       @serializer = serializer
 
       @max_inline_relations_depth = opts.fetch(:max_inline_relations_depth)
       @default_inline_relations_depth = 0
+      @collection_transformer = opts[:collection_transformer]
     end
 
     # Render an object to json, using export and security properties
@@ -41,6 +44,9 @@ module VCAP::CloudController::RestController
       )
 
       eager_loaded_object = eager_loaded_objects.where(id: obj.id).all.first
+
+      transform_opts = opts[:transform_opts] || {}
+      collection_transformer.transform(eager_loaded_object, transform_opts) if collection_transformer
 
       # The class of object and eager_loaded_object could be different
       # if they are part of STI. Attributes exported by the object

--- a/spec/api/api_version_spec.rb
+++ b/spec/api/api_version_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'digest/sha1'
 
 describe 'Stable API warning system', api_version_check: true do
-  API_FOLDER_CHECKSUM = 'afab157845f4e649549f36325d302a0f971ec347'
+  API_FOLDER_CHECKSUM = '2f230088db75c9448cb78f5355a4fab3b1577366'
 
   it 'double-checks the version' do
     expect(VCAP::CloudController::Constants::API_VERSION).to eq('2.25.0')

--- a/spec/api/documentation/organizations_api_spec.rb
+++ b/spec/api/documentation/organizations_api_spec.rb
@@ -86,6 +86,30 @@ resource 'Organizations', type: [:api, :legacy_api] do
       end
     end
 
+    describe 'Quota Usage' do
+      before do
+        organization.add_space(space)
+        app_obj.add_route(route)
+        space.add_service_instance(service_instance)
+        space.add_app(app_obj)
+      end
+
+      let(:space) { VCAP::CloudController::Space.make(organization: organization) }
+      let(:route) { VCAP::CloudController::Route.make(space: space) }
+      let(:service_instance) { VCAP::CloudController::ManagedServiceInstance.make(space: space) }
+      let(:app_obj) { VCAP::CloudController::AppFactory.make(space: space, instances: 1, memory: 500, state: 'STARTED') }
+
+      get '/v2/organizations/:guid/quota_usage' do
+        example 'Retrieving quota usaged in the Organization' do
+          client.get "/v2/organizations/#{guid}/quota_usage", {}, headers
+
+          expect(status).to eq(200)
+          expect(parsed_response['entity']['org_usage']).
+            to include('routes', 'services', 'memory')
+        end
+      end
+    end
+
     describe 'Spaces' do
       before do
         VCAP::CloudController::Space.make(organization: organization)

--- a/spec/unit/collection_transformers/quota_usage_populator_spec.rb
+++ b/spec/unit/collection_transformers/quota_usage_populator_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+module VCAP::CloudController
+  describe QuotaUsagePopulator do
+    let(:quotaUsage_populator) { QuotaUsagePopulator.new }
+    let(:quota_definition) { QuotaDefinition.make }
+    let(:quota_definition_guid) { quota_definition.guid }
+    let(:org) { Organization.make_unsaved(quota_definition: quota_definition, quota_definition_guid: quota_definition_guid) }
+    let(:space) { Space.make(organization: org) }
+    let(:domain) { PrivateDomain.make(owning_organization: org) }
+    let(:route) { Route.make(domain: domain, space: space) }
+    let(:service_instance) { ManagedServiceInstance.make(space: space) }
+    let(:app) { AppFactory.make(space: space, instances: 1, memory: 500, state: 'STARTED') }
+
+    before do
+      org.save
+      org.add_space(space)
+      app.add_route(route)
+      space.add_service_instance(service_instance)
+      space.add_app(app)
+    end
+
+    describe 'transform' do
+      it 'populates users with usernames from UAA' do
+        quotaUsage_populator.transform(quota_definition, organization_id: org.id)
+        expect(quota_definition.org_usage).to eq({ 'routes' => 1, 'services' => 1, 'memory' => 500 })
+      end
+    end
+  end
+end

--- a/spec/unit/controllers/runtime/organizations_controller_spec.rb
+++ b/spec/unit/controllers/runtime/organizations_controller_spec.rb
@@ -204,6 +204,24 @@ module VCAP::CloudController
       end
     end
 
+    describe 'GET /v2/organizations/:guid/quota_usage' do
+      context 'for an organization that does not exist' do
+        it 'returns a 404' do
+          get '/v2/organizations/foobar/quota_usage', {}, admin_headers
+          expect(last_response.status).to eq(404)
+        end
+      end
+
+      context 'when the user does not have permissions to read' do
+        let(:user) { User.make }
+
+        it 'returns a 403' do
+          get "/v2/organizations/#{org.guid}/quota_usage", {}, headers_for(user)
+          expect(last_response.status).to eq(403)
+        end
+      end
+    end
+
     describe 'GET', '/v2/organizations/:guid/services' do
       let(:other_org) { Organization.make }
       let(:space_one) { Space.make(organization: org) }

--- a/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
+++ b/spec/unit/lib/cloud_controller/dependency_locator_spec.rb
@@ -395,6 +395,34 @@ describe CloudController::DependencyLocator do
     end
   end
 
+  describe '#quota_usage_populating_collection_renderer' do
+    it 'returns collection renderer with a QuotaUsagePopulator transformer' do
+      renderer = locator.quota_usage_populating_collection_renderer
+      expect(renderer.collection_transformer).to be_a(VCAP::CloudController::QuotaUsagePopulator)
+    end
+  end
+
+  describe '#object_collection_renderer' do
+    it 'returns collection renderer configured via config' do
+      eager_loader = instance_of(VCAP::CloudController::RestController::SecureEagerLoader)
+      serializer = instance_of(VCAP::CloudController::RestController::PreloadedObjectSerializer)
+      opts = {
+        max_inline_relations_depth: 100_002,
+        collection_transformer: nil
+      }
+
+      TestConfig.override(renderer: opts)
+
+      renderer = double('renderer')
+      expect(VCAP::CloudController::RestController::ObjectRenderer).
+        to receive(:new).
+        with(eager_loader, serializer, opts).
+        and_return(renderer)
+
+      expect(locator.object_collection_renderer).to eq(renderer)
+    end
+  end
+
   describe '#username_lookup_uaa_client' do
     it 'returns a uaa client with credentials for lookuping up usernames' do
       uaa_client = locator.username_lookup_uaa_client

--- a/spec/unit/lib/rest_controller/object_renderer_spec.rb
+++ b/spec/unit/lib/rest_controller/object_renderer_spec.rb
@@ -5,7 +5,13 @@ module VCAP::CloudController::RestController
     subject(:renderer) { described_class.new(eager_loader, serializer, renderer_opts) }
     let(:eager_loader) { SecureEagerLoader.new }
     let(:serializer) { PreloadedObjectSerializer.new }
-    let(:renderer_opts) { { max_inline_relations_depth: 100_000 } }
+    let(:collection_transformer) { nil }
+    let(:renderer_opts) do
+      {
+         max_inline_relations_depth: 100_000,
+         collection_transformer: collection_transformer
+      }
+    end
 
     describe '#render_json' do
       let(:controller) { VCAP::CloudController::TestModelSecondLevelsController }
@@ -41,6 +47,18 @@ module VCAP::CloudController::RestController
         it 'renders json response' do
           result = subject.render_json(controller, instance, opts)
           expect(result).to be_instance_of(String)
+        end
+      end
+
+      context 'when collection_transformer is given' do
+        let(:collection_transformer) { double('collection_transformer') }
+
+        it 'passes the populated dataset to the transformer' do
+          expect(collection_transformer).to receive(:transform) do |collection|
+            expect(collection).to eq(instance)
+          end
+
+          subject.render_json(controller, instance, opts)
         end
       end
     end

--- a/spec/unit/models/runtime/quota_definition_spec.rb
+++ b/spec/unit/models/runtime/quota_definition_spec.rb
@@ -96,5 +96,16 @@ module VCAP::CloudController
         end
       end
     end
+
+    describe '#to_hash' do
+      it 'does not include org_usage when org_usage has not been set' do
+        expect(quota_definition.to_hash).to_not include('org_usage')
+      end
+
+      it 'includes org_usage when org_usage has been set' do
+        quota_definition.org_usage = 'someusage'
+        expect(quota_definition.to_hash).to include('org_usage')
+      end
+    end
   end
 end


### PR DESCRIPTION
Provide current status of routes, service instances and memory usage of organization quota.

#[91309412]

Issue:
http://rnd-github.huawei.com/cloudfoundry/cloud_controller_ng/issues/7